### PR TITLE
fix(docs): use GitHub theme fragment syntax for logo

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,11 +1,8 @@
 # boop
 
 <p>
-  <picture >
-    <source media="(prefers-color-scheme: dark)" srcset="docs/boop-dark.png">
-    <source media="(prefers-color-scheme: light)" srcset="docs/boop-light.png">
-    <img alt="Boop Boop" src="docs/boop-dark.png" width="20%">
-  </picture>
+  <img alt="Boop Boop" src="docs/boop-dark.png#gh-dark-mode-only" width="20%">
+  <img alt="Boop Boop" src="docs/boop-light.png#gh-light-mode-only" width="20%">
   <br>
   <a href="https://github.com/sethrylan/boop/releases"><img src="https://img.shields.io/github/release/sethrylan/boop.svg" alt="Latest Release"></a>
   <a href="https://github.com/sethrylan/boop/actions"><img src="https://github.com/sethrylan/boop/workflows/ci/badge.svg" alt="Build Status"></a>


### PR DESCRIPTION
## Summary

- Replace `<picture>` + `prefers-color-scheme` media queries with GitHub's `#gh-dark-mode-only` / `#gh-light-mode-only` URL fragment syntax
- The CSS media query approach requires a logged-in user's saved color preference to resolve server-side — anonymous visitors see no image
- The fragment syntax is GitHub's documented API for theme-aware images and works for all visitors

## Test plan

- [ ] View the README on GitHub while logged out — logo should render
- [ ] View in dark mode — dark variant shown
- [ ] View in light mode — light variant shown