### PR TITLE
fix: remove unused gosec nolint

### DIFF
--- a/worker.go
+++ b/worker.go
@@ -60,7 +60,7 @@ func worker(
 			req = req.WithContext(httptrace.WithClientTrace(ctx, trace))
 		}
 
-		resp, err := client.Do(req) //nolint:gosec // req.URL is provided by the user as a CLI argument, not untrusted input
+		resp, err := client.Do(req)
 		if err != nil {
 			rec.failed = true
 			rec.errMsg = err.Error()


### PR DESCRIPTION
## Summary

Remove an unused gosec nolint directive from the worker request execution path so nolintlint passes cleanly.

## Validation

- mise exec go@1.26 -- go vet ./...
- mise exec go@1.26 -- go fmt ./...
- mise exec go@1.26 golangci-lint@v2.8.0 -- golangci-lint run
- mise exec go@1.26 -- go test ./...